### PR TITLE
Test and project structure enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: php
 php:
   - '5.6'
+  - '7.0'
   - '7.1'
   - '7.2'
+  - '7.3'
   - nightly
 services:
   - mysql
 before_script:
-- mysql -e "create database IF NOT EXISTS travisdb;" 
+  - mysql -e "create database IF NOT EXISTS travisdb;"
+  - composer install --no-interaction
+
+script:
+  - php vendor/bin/phpunit
+

--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,47 @@
+<?php
+
+spl_autoload_register(function ($class) {
+    // project-specific namespace prefix
+    $prefix = 'eftec\\';
+    // base directory for the namespace prefix
+    $baseDir = __DIR__.'/lib/';
+    // does the class use the namespace prefix?
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        // no, move to the next registered autoloader
+        return;
+    }
+    // get the relative class name
+    $relativeClass = substr($class, $len);
+    // replace the namespace prefix with the base directory, replace namespace
+    // separators with directory separators in the relative class name, append
+    // with .php
+    $file = $baseDir.str_replace('\\', '/', $relativeClass).'.php';
+    // if the file exists, require it
+    if (file_exists($file)) {
+        require $file;
+    }
+});
+
+spl_autoload_register(function ($class) {
+    // project-specific namespace prefix
+    $prefix = 'eftec\\tests\\';
+    // base directory for the namespace prefix
+    $baseDir = __DIR__.'/tests/';
+    // does the class use the namespace prefix?
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        // no, move to the next registered autoloader
+        return;
+    }
+    // get the relative class name
+    $relativeClass = substr($class, $len);
+    // replace the namespace prefix with the base directory, replace namespace
+    // separators with directory separators in the relative class name, append
+    // with .php
+    $file = $baseDir.str_replace('\\', '/', $relativeClass).'.php';
+    // if the file exists, require it
+    if (file_exists($file)) {
+        require $file;
+    }
+});

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,11 @@
         "eftec\\": "lib/"
       }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "eftec\\tests\\": "tests/"
+        }
+    },
     "require": {
         "ext-mysqli": "*",
         "ext-json": "*"
@@ -29,7 +34,7 @@
         "eftec/validationone": "For keeping and storing the messages"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7 || ^6.5"
     }
 }
 

--- a/lib/DaoOne.php
+++ b/lib/DaoOne.php
@@ -513,7 +513,7 @@ class DaoOne
 
 			}
 		} else {
-			
+
 			$col=array();
 			$colT=array();
 			$p=array();
@@ -608,7 +608,7 @@ class DaoOne
 	}
 
 	/**
-	 * Run builder query and returns a mysqli_result. 
+	 * Run builder query and returns a mysqli_result.
 	 * @param bool $returnArray true=return an array. False return a mysqli_result
 	 * @return bool|\mysqli_result
 	 * @throws Exception

--- a/tests/DaoOneTest.php
+++ b/tests/DaoOneTest.php
@@ -1,5 +1,7 @@
 <?php
+
 namespace eftec\tests;
+
 use eftec\DaoOne;
 use Exception;
 use PHPUnit\Framework\TestCase;
@@ -7,12 +9,10 @@ use PHPUnit\Framework\TestCase;
 
 class DaoOneTest extends TestCase
 {
-    var $daoOne;
+    protected $daoOne;
 
-    public function __construct($name = null, array $data = [], $dataName = '')
+    public function setUp()
     {
-        parent::__construct($name, $data, $dataName);
-        //you could change it.
         $this->daoOne=new DaoOne("127.0.0.1","travis","","travisdb");
         $this->daoOne->connect();
     }
@@ -46,7 +46,7 @@ class DaoOneTest extends TestCase
     public function test_open()
     {
         //$this->expectException(\Exception::class);
-	    
+
         //$this->daoOne->open(true);
 	    try {
 		    $r=$this->daoOne->runRawQuery('drop table product_category');
@@ -55,13 +55,13 @@ class DaoOneTest extends TestCase
 		    $r=false;
 	    	// drops silently
 	    }
-	    
-	    
+
+
 	    $sqlT2="CREATE TABLE `product_category` (
 	    `id_category` INT NOT NULL,
 	    `catname` VARCHAR(45) NULL,
 	    PRIMARY KEY (`id_category`));";
-	
+
 	    try {
 		    $r=$this->daoOne->runRawQuery($sqlT2);
 	    } catch (Exception $e) {
@@ -72,7 +72,7 @@ class DaoOneTest extends TestCase
 	    $r=$this->daoOne->set(['id_category' => 1, 'catname' => 'cheap'])
 		    ->from('product_category')->insert();
 	    $this->assertEquals(0,$r,'insert must value 0');
-	    
+
     }
 
     public function test_close()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,25 +1,7 @@
 <?php
 
-
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require_once __DIR__ . '/../vendor/autoload.php';
 } else {
-    function create_autoloader($prefix, $base_dir) {
-        return function ($class) use ($prefix, $base_dir) {
-            if (strncmp($prefix, $class, strlen($prefix)) !== 0) {
-                return;
-            }
-
-            $file = $base_dir . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
-
-            if (file_exists($file)) {
-                require $file;
-            }
-        };
-    }
-
-    spl_autoload_register(create_autoloader("eftec\\", __DIR__ . '/../lib/'));
-    spl_autoload_register(create_autoloader("eftec\\tests\\", __DIR__ . '/'));
+    require_once __DIR__ . '/../autoload.php';
 }
-
-


### PR DESCRIPTION
# Changed log
- Add `php-7.0` and `php-7.3` tests in Travis CI build.
- Add `before_script` and `script` block during Travis CI build.
- Remove manual autoloader from `tests/bootstrap.php` and ddd `autoload.php` to load the required classes manually with `PSR-4` autoloader.
- Replace `constructor inheritance` approach with `setUp` method inside `DaoOneTest` class to initialize the `daoOne` class instance.